### PR TITLE
Add JSON⇔YAML converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - **✒ Minify/Clean ツール**：HTML/CSS/JS を簡易的に圧縮・復元します。
 - **🔢 文字数カウンター**：入力したテキストの文字数、行数、段落数をカウントします。
 - **📄 Markdown ビュワー ([Demo](https://bellsanct.github.io/markdown-editor/))**：Markdown テキストをその場でレンダリングして確認できます。
+- **🔁 JSON⇔YAML 変換**：JSON と YAML を相互に変換するツールです。
 
 ## セットアップ
 ```bash

--- a/src/pages/JsonYaml.vue
+++ b/src/pages/JsonYaml.vue
@@ -1,0 +1,106 @@
+<template>
+  <h1 class="text-4xl bg-gray-800 text-white text-center font-bold py-6">
+    JSON⇔YAML 変換
+  </h1>
+  <div class="min-h-screen bg-gray-800 pt-10 text-white flex flex-col items-center justify-top">
+    <div class="flex flex-col md:flex-row w-3/4 space-y-4 md:space-y-0 md:space-x-4">
+      <div class="flex-1">
+        <label class="block mb-2">JSON</label>
+        <textarea
+          v-model="jsonText"
+          class="textarea textarea-bordered w-full h-48 bg-gray-700 text-white p-2"
+        ></textarea>
+        <div class="flex justify-between mt-2">
+          <button
+            class="bg-cyan-700 hover:bg-cyan-900 text-white font-bold py-2 px-4 rounded"
+            @click="jsonToYaml"
+          >
+            JSON → YAML
+          </button>
+          <button
+            class="bg-gray-600 hover:bg-gray-500 text-white font-bold py-2 px-4 rounded"
+            @click="copy(jsonText)"
+          >
+            コピー
+          </button>
+        </div>
+      </div>
+      <div class="flex-1">
+        <label class="block mb-2">YAML</label>
+        <textarea
+          v-model="yamlText"
+          class="textarea textarea-bordered w-full h-48 bg-gray-700 text-white p-2"
+        ></textarea>
+        <div class="flex justify-between mt-2">
+          <button
+            class="bg-cyan-700 hover:bg-cyan-900 text-white font-bold py-2 px-4 rounded"
+            @click="yamlToJson"
+          >
+            YAML → JSON
+          </button>
+          <button
+            class="bg-gray-600 hover:bg-gray-500 text-white font-bold py-2 px-4 rounded"
+            @click="copy(yamlText)"
+          >
+            コピー
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      jsonText: "",
+      yamlText: "",
+      yamlLib: null,
+    };
+  },
+  methods: {
+    async ensureLib() {
+      if (!this.yamlLib) {
+        this.yamlLib = await import(
+          "https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/+esm"
+        );
+      }
+    },
+    async jsonToYaml() {
+      await this.ensureLib();
+      try {
+        const obj = JSON.parse(this.jsonText || "{}");
+        this.yamlText = this.yamlLib.dump(obj);
+      } catch (e) {
+        alert("JSONの解析に失敗しました");
+      }
+    },
+    async yamlToJson() {
+      await this.ensureLib();
+      try {
+        const obj = this.yamlLib.load(this.yamlText || "");
+        this.jsonText = JSON.stringify(obj, null, 2);
+      } catch (e) {
+        alert("YAMLの解析に失敗しました");
+      }
+    },
+    copy(text) {
+      navigator.clipboard
+        .writeText(text)
+        .then(() => {
+          alert("コピーしました！");
+        })
+        .catch((err) => {
+          console.error("コピーに失敗しました: ", err);
+        });
+    },
+  },
+};
+</script>
+
+<style>
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
+</style>

--- a/src/pages/OverView.vue
+++ b/src/pages/OverView.vue
@@ -54,6 +54,22 @@
             Markdownビュワーを試す
           </a>
         </div>
+        <!-- JSON/YAML 変換カード -->
+        <div class="bg-gray-700 p-6 rounded-lg shadow-lg flex flex-col">
+          <div class="flex items-center mb-4">
+            <span class="text-4xl mr-3">🔁</span>
+            <h2 class="text-2xl font-semibold">JSON⇔YAML変換</h2>
+          </div>
+          <p class="mb-4">
+            JSON形式とYAML形式を相互に変換するシンプルなツールです。
+          </p>
+          <router-link
+            to="/JsonYaml"
+            class="mt-auto inline-block bg-cyan-700 hover:bg-cyan-900 text-white text-center font-bold py-2 px-4 rounded"
+          >
+            JSON⇔YAML変換を試す
+          </router-link>
+        </div>
       </div>
     </div>
   </div>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -5,6 +5,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import OverView from "@/pages/OverView.vue";
 import CharCalc from "@/pages/CharCalc.vue";
 import MinifyTool from "@/pages/MinifyTool.vue";
+import JsonYaml from "@/pages/JsonYaml.vue";
 
 const routes = [
   {
@@ -21,6 +22,11 @@ const routes = [
     path: "/MinifyTool",
     name: "MinifyTool",
     component: MinifyTool,
+  },
+  {
+    path: "/JsonYaml",
+    name: "JsonYaml",
+    component: JsonYaml,
   },
 ];
 


### PR DESCRIPTION
## Summary
- add new page `JsonYaml` for converting JSON and YAML
- link JsonYaml page from router
- add JsonYaml card in OverView
- document the converter in README

## Testing
- `npm run lint` *(fails: `vue-cli-service` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8f232d008327ae58b8f397574ed7