### PR TITLE
Add js-yaml dependency and simplify converter

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "core-js": "^3.8.3",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
+    "js-yaml": "^4.1.0",
     "vue": "^3.2.13",
     "vue-router": "^4.0.13"
   },

--- a/src/pages/JsonYaml.vue
+++ b/src/pages/JsonYaml.vue
@@ -51,35 +51,26 @@
 </template>
 
 <script>
+import * as yaml from "js-yaml";
 export default {
   data() {
     return {
       jsonText: "",
       yamlText: "",
-      yamlLib: null,
     };
   },
   methods: {
-    async ensureLib() {
-      if (!this.yamlLib) {
-        this.yamlLib = await import(
-          "https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/+esm"
-        );
-      }
-    },
     async jsonToYaml() {
-      await this.ensureLib();
       try {
         const obj = JSON.parse(this.jsonText || "{}");
-        this.yamlText = this.yamlLib.dump(obj);
+        this.yamlText = yaml.dump(obj);
       } catch (e) {
         alert("JSONの解析に失敗しました");
       }
     },
     async yamlToJson() {
-      await this.ensureLib();
       try {
-        const obj = this.yamlLib.load(this.yamlText || "");
+        const obj = yaml.load(this.yamlText || "");
         this.jsonText = JSON.stringify(obj, null, 2);
       } catch (e) {
         alert("YAMLの解析に失敗しました");


### PR DESCRIPTION
## Summary
- add `js-yaml` dependency
- use `js-yaml` directly in JSON/YAML converter

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run serve` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9246b8888327b7520c1ca3027d9f