### PR TITLE
Add indentation guides to input areas

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -1,3 +1,18 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --indent-guide-size: 2ch;
+}
+
+.indent-guide {
+  background-image: repeating-linear-gradient(
+    90deg,
+    transparent,
+    transparent calc(var(--indent-guide-size) - 1px),
+    rgba(255, 255, 255, 0.1) calc(var(--indent-guide-size) - 1px),
+    rgba(255, 255, 255, 0.1) var(--indent-guide-size)
+  );
+  background-attachment: local;
+}

--- a/src/pages/JsonYaml.vue
+++ b/src/pages/JsonYaml.vue
@@ -8,7 +8,7 @@
         <label class="block mb-2">JSON</label>
         <textarea
           v-model="jsonText"
-          class="textarea textarea-bordered w-full h-48 bg-gray-700 text-white p-2"
+          class="textarea textarea-bordered w-full h-48 bg-gray-700 text-white p-2 indent-guide"
         ></textarea>
         <div class="flex justify-between mt-2">
           <button
@@ -29,7 +29,7 @@
         <label class="block mb-2">YAML</label>
         <textarea
           v-model="yamlText"
-          class="textarea textarea-bordered w-full h-48 bg-gray-700 text-white p-2"
+          class="textarea textarea-bordered w-full h-48 bg-gray-700 text-white p-2 indent-guide"
         ></textarea>
         <div class="flex justify-between mt-2">
           <button

--- a/src/pages/MinifyTool.vue
+++ b/src/pages/MinifyTool.vue
@@ -37,7 +37,7 @@
     </div>
 
     <textarea
-      class="textarea textarea-bordered w-3/4 h-48 bg-gray-700 text-white p-4"
+      class="textarea textarea-bordered w-3/4 h-48 bg-gray-700 text-white p-4 indent-guide"
       placeholder="ここにコードを入力してください"
       v-model="inputCode"
     ></textarea>


### PR DESCRIPTION
## Summary
- add simple indentation guides using a repeating background
- apply new style to JSON/YAML converter textareas
- apply new style to Minify/Clean tool textarea

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fcb60a4a48327a9ecf7595327e9a5